### PR TITLE
Fixes WebSocketConnect.Id always recomputing

### DIFF
--- a/Demo.AspNetCore.WebSockets/Infrastructure/WebSocketConnection.cs
+++ b/Demo.AspNetCore.WebSockets/Infrastructure/WebSocketConnection.cs
@@ -16,7 +16,7 @@ namespace Demo.AspNetCore.WebSockets.Infrastructure
         #endregion
 
         #region Properties
-        public Guid Id => Guid.NewGuid();
+        public Guid Id { get; } = Guid.NewGuid();
 
         public WebSocketCloseStatus? CloseStatus { get; private set; } = null;
 


### PR DESCRIPTION
The `WebSocketConnectiion.Id` property was written using the computed
lambda syntax instead of the property initializer syntax.